### PR TITLE
key punches is 5 Two i

### DIFF
--- a/_data/poems/is-5/two-i.yaml
+++ b/_data/poems/is-5/two-i.yaml
@@ -1,3 +1,55 @@
 title: TWO I
 
+titled: false
+
+nowrap: true
+
 first_line: the season ’tis,my lovely lambs,
+
+text: |-1
+ the season ’tis,my lovely lambs,
+
+ of Sumner Volstead Christ and Co.
+ the epoch of Mann’s righteousness
+ the age of dollars and no sense.
+ Which being quite beyond dispute
+
+ as prove from Troy (N. Y.) to Cairo
+ (Egypt) the luminous dithyrambs
+ of large immaculate unmute
+ antibolschevistic gents
+ (each manufacturing word by word
+ his own unrivalled brand of pyro
+ -technic blurb anent the (hic)
+ hero dead that gladly (sic)
+ in far lands perished of unheard
+ of maladies including flu)
+
+ my little darlings, let us now
+ passionately remember how—
+ braving the worst, of peril heedless,
+ each braver than the other, each
+ (a typewriter within his reach)
+ upon his fearless derrière
+ sturdily seated—Colonel Needless
+ To Name and General You know who
+ a string of pretty medals drew
+
+ (while messrs jack james john and jim
+ in token of their country’s love
+ received my dears the order of
+ The Artificial Arm and Limb)
+
+ —or,since bloodshed and kindred questions
+ inhibit unprepared digestions,
+ come: let us mildly contemplate
+ beginning with his wellfilled pants
+ earth’s biggest grafter, nothing less;
+ the Honorable Mr. (guess)
+ who, breathing on the ear of fate,
+ landed a seat in the legislat-
+ ure whereas tommy so and so
+ (an erring child of circumstance
+ whom the bulls nabbed at 33rd)
+
+ pulled six months for selling snow


### PR DESCRIPTION
Dipping my toe back in. 

I'll note here that some of spacing in [the first edition scan on archive.org](https://archive.org/details/is-5-ee-cummings/page/n70/mode/1up) appears to be different in the Firmage's _E.E. Cummings Complete Poems 1904-1962_, which I used as a source when keypunching older poems. 

As an example: 

```
 as prove from Troy (N. Y.) to Cairo
 (Egypt) the luminous dithyrambs
```

appears in Firmage pretty decisively as:
```
 as prove from Troy(N.Y.)to Cairo
 (Egypt)the luminous dithyrambs
```

Figuring that we're favoring the scan of the first edition, I tried to keypunch the spacing to that edition when there was a discrepancy. But I did think it was of note. 